### PR TITLE
fix: enable recipient read response creation for operator

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,7 +1,10 @@
 {
-  "extends": ["standard", "plugin:jest/recommended" ],
+  "extends": ["standard", "plugin:jest/recommended"],
   "plugins": ["jest"],
   "env": {
     "node": true
+  },
+  "rules": {
+    "jest/no-disabled-tests": "off"
   }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,8 +3,5 @@
   "plugins": ["jest"],
   "env": {
     "node": true
-  },
-  "rules": {
-    "jest/no-disabled-tests": "off"
   }
 }

--- a/__test__/schemas.test.js
+++ b/__test__/schemas.test.js
@@ -124,7 +124,7 @@ describe('schemas', () => {
     // This would should be an invalid object
     // Checking if values are undefined is not possible in joi.
     //  Hopefully and probably, it will not cause any problems when parsing
-    it.skip('throws if permission.denied exists but is undefined', async () => {
+    it.skip('throws if permission.denied exists but is undefined', async () => { // eslint-disable jest/no-disabled-tests
       connection.permissions.denied = undefined
       await expect(
         schemas.CONNECTION.validate(connection)
@@ -134,7 +134,7 @@ describe('schemas', () => {
     // This would should be an invalid object
     // Checking if values are undefined is not possible in joi.
     //  Hopefully and probably, it will not cause any problems when parsing
-    it.skip('throws if permission.approved exists but is undefined', async () => {
+    it.skip('throws if permission.approved exists but is undefined', async () => { // eslint-disable jest/no-disabled-tests
       connection.permissions.approved = undefined
       await expect(
         schemas.CONNECTION.validate(connection)
@@ -144,7 +144,7 @@ describe('schemas', () => {
     // This would should be an invalid object
     // Checking if values are undefined is not possible in joi.
     //  Hopefully and probably, it will not cause any problems when parsing
-    it.skip('throws if permissions exists but is undefined', async () => {
+    it.skip('throws if permissions exists but is undefined', async () => { // eslint-disable jest/no-disabled-tests
       connection.permissions = undefined
       await expect(
         schemas.CONNECTION.validate(connection)

--- a/__test__/schemas.test.js
+++ b/__test__/schemas.test.js
@@ -63,6 +63,15 @@ describe('schemas', () => {
         sid: 'sdkfhdkskdfd',
         sub: 'baa949aa-fbb5-4aad-8351-d6ef219dd07b',
         permissions: {
+          denied: [
+            {
+              id: '392c6472-40e4-4e2b-92e2-77a46c1900b8',
+              domain: 'https://mycv.work',
+              area: 'edumacation',
+              type: 'WRITE',
+              lawfulBasis: 'CONSENT'
+            }
+          ],
           approved: [
             {
               id: '91910133-4024-4641-a7c7-91fb6e11588e',
@@ -91,24 +100,69 @@ describe('schemas', () => {
         }
       }
     })
+
     it('validates a correct payload', async () => {
       await expect(
         schemas.CONNECTION.validate(connection)
       ).resolves.not.toThrow()
     })
-    describe('CONNECTION_RESPONSE', () => {
-      it('validates a correct payload', async () => {
-        const payload = {
-          ...jwtDefaults,
-          aud: 'https://smoothoperator',
-          type: 'CONNECTION_RESPONSE',
-          payload:
-            'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJsb2dnZWRJbkFzIjoiYWRtaW4iLCJpYXQiOjE0MjI3Nzk2Mzh9.gzSraSYS8EXBxLN_oWnFSRgCzcmJmMjLiuyu5CSpyHI'
-        }
-        await expect(
-          schemas.CONNECTION_RESPONSE.validate(payload)
-        ).resolves.not.toThrow()
-      })
+
+    it('validates a correct payload without any permissions', async () => {
+      delete connection.permissions
+      await expect(
+        schemas.CONNECTION.validate(connection)
+      ).resolves.not.toThrow()
+    })
+    
+    it('throws if permissions exists but is empty', async () => {
+      connection.permissions = {}
+      await expect(
+        schemas.CONNECTION.validate(connection)
+      ).rejects.toThrow()
+    })
+
+    // This would should be an invalid object
+    // Checking if values are undefined is not possible in joi. 
+    //  Hopefully and probably, it will not cause any problems when parsing
+    it.skip('throws if permission.denied exists but is undefined', async () => {
+      connection.permissions.denied = undefined
+      await expect(
+        schemas.CONNECTION.validate(connection)
+      ).rejects.toThrow()
+    })
+
+    // This would should be an invalid object
+    // Checking if values are undefined is not possible in joi. 
+    //  Hopefully and probably, it will not cause any problems when parsing
+    it.skip('throws if permission.approved exists but is undefined', async () => {
+      connection.permissions.approved = undefined
+      await expect(
+        schemas.CONNECTION.validate(connection)
+      ).rejects.toThrow()
+    })
+
+    // This would should be an invalid object
+    // Checking if values are undefined is not possible in joi. 
+    //  Hopefully and probably, it will not cause any problems when parsing
+    it.skip('throws if permissions exists but is undefined', async () => {
+      connection.permissions = undefined
+      await expect(
+        schemas.CONNECTION.validate(connection)
+      ).rejects.toThrow()
+    })
+  })
+  describe('CONNECTION_RESPONSE', () => {
+    it('validates a correct payload', async () => {
+      const payload = {
+        ...jwtDefaults,
+        aud: 'https://smoothoperator',
+        type: 'CONNECTION_RESPONSE',
+        payload:
+          'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJsb2dnZWRJbkFzIjoiYWRtaW4iLCJpYXQiOjE0MjI3Nzk2Mzh9.gzSraSYS8EXBxLN_oWnFSRgCzcmJmMjLiuyu5CSpyHI'
+      }
+      await expect(
+        schemas.CONNECTION_RESPONSE.validate(payload)
+      ).resolves.not.toThrow()
     })
   })
   describe('RECIPIENTS_READ_RESPONSE', () => {

--- a/__test__/schemas.test.js
+++ b/__test__/schemas.test.js
@@ -113,7 +113,7 @@ describe('schemas', () => {
         schemas.CONNECTION.validate(connection)
       ).resolves.not.toThrow()
     })
-    
+
     it('throws if permissions exists but is empty', async () => {
       connection.permissions = {}
       await expect(
@@ -122,7 +122,7 @@ describe('schemas', () => {
     })
 
     // This would should be an invalid object
-    // Checking if values are undefined is not possible in joi. 
+    // Checking if values are undefined is not possible in joi.
     //  Hopefully and probably, it will not cause any problems when parsing
     it.skip('throws if permission.denied exists but is undefined', async () => {
       connection.permissions.denied = undefined
@@ -132,7 +132,7 @@ describe('schemas', () => {
     })
 
     // This would should be an invalid object
-    // Checking if values are undefined is not possible in joi. 
+    // Checking if values are undefined is not possible in joi.
     //  Hopefully and probably, it will not cause any problems when parsing
     it.skip('throws if permission.approved exists but is undefined', async () => {
       connection.permissions.approved = undefined
@@ -142,7 +142,7 @@ describe('schemas', () => {
     })
 
     // This would should be an invalid object
-    // Checking if values are undefined is not possible in joi. 
+    // Checking if values are undefined is not possible in joi.
     //  Hopefully and probably, it will not cause any problems when parsing
     it.skip('throws if permissions exists but is undefined', async () => {
       connection.permissions = undefined

--- a/lib/schemas.js
+++ b/lib/schemas.js
@@ -172,11 +172,17 @@ const CONNECTION = Joi.object({
   type: 'CONNECTION',
   sid: Joi.string().required(),
   sub: Joi.string().uuid({ version: 'uuidv4' }).required(),
-  permissions: Joi.object({
-    approved: PERMISSION_ARRAY.min(1),
-    denied: Joi.array().items(PERMISSION_DENIED).min(1)
-  })
-}).required()
+  permissions: Joi.alternatives().try(
+    Joi.object({
+      approved: PERMISSION_ARRAY.min(1),
+      denied: Joi.array().items(PERMISSION_DENIED).min(1).required()
+    }),
+    Joi.object({
+      approved: PERMISSION_ARRAY.min(1).required(),
+      denied: Joi.array().items(PERMISSION_DENIED).min(1)
+    }),
+  )
+})
 
 // device -> operator
 const CONNECTION_RESPONSE = Joi.object({
@@ -304,7 +310,7 @@ const RECIPIENTS_WRITE = Joi.object({
   })).min(1).required()
 }).required()
 
-// Schemas used from mobile device allowing jwk in payload
+// Messages sent from the mobile device, which includes the jwk in payload
 const deviceSchemas = [
   ACCOUNT_REGISTRATION,
   CONNECTION_INIT,
@@ -313,7 +319,6 @@ const deviceSchemas = [
   LOGIN,
   LOGIN_RESPONSE,
   RECIPIENTS_READ_REQUEST,
-  RECIPIENTS_READ_RESPONSE,
   RECIPIENTS_WRITE
 ]
 

--- a/lib/schemas.js
+++ b/lib/schemas.js
@@ -180,7 +180,7 @@ const CONNECTION = Joi.object({
     Joi.object({
       approved: PERMISSION_ARRAY.min(1).required(),
       denied: Joi.array().items(PERMISSION_DENIED).min(1)
-    }),
+    })
   )
 })
 


### PR DESCRIPTION
Mainly, this remove RECIPIENTS_READ_RESPONSE from deviceSchemas, since this message is created by the operator (not the app)

also enforced length of "denied", in CONNECTION schema, to be atleast one, if this field is included.

This PR also removes some .optional() (since that is the default behaviour)

